### PR TITLE
Improve the detection of taps

### DIFF
--- a/MiddleClick/Controller.m
+++ b/MiddleClick/Controller.m
@@ -286,8 +286,9 @@ int touchCallback(int device, Finger* data, int nFingers, double timestamp,
     }
   } else {
     if (nFingers == 0) {
+      NSTimeInterval elapsedTime = touchStartTime ? -[touchStartTime timeIntervalSinceNow] : 0;
       touchStartTime = NULL;
-      if (middleclickX + middleclickY) {
+      if (middleclickX + middleclickY && elapsedTime <= 0.5f) {
         float delta = ABS(middleclickX - middleclickX2) + ABS(middleclickY - middleclickY2);
         if (delta < 0.4f) {
           // Emulate a middle click

--- a/MiddleClick/Controller.m
+++ b/MiddleClick/Controller.m
@@ -1,4 +1,5 @@
 #import "Controller.h"
+#import "PreferenceKeys.h"
 #include "TrayMenu.h"
 #import <Cocoa/Cocoa.h>
 #include <CoreFoundation/CoreFoundation.h>
@@ -66,7 +67,7 @@ CFRunLoopSourceRef currentRunLoopSource;
   threeDown = NO;
   wasThreeDown = NO;
   
-  fingersQua = [[NSUserDefaults standardUserDefaults] integerForKey:@"fingers"];
+  fingersQua = [[NSUserDefaults standardUserDefaults] integerForKey:kFingersNum];
   
   NSString* needToClickNullable = [[NSUserDefaults standardUserDefaults] valueForKey:@"needClick"];
   needToClick = needToClickNullable ? [[NSUserDefaults standardUserDefaults] boolForKey:@"needClick"] : [self getIsSystemTapToClickDisabled];
@@ -270,7 +271,9 @@ int touchCallback(int device, Finger* data, int nFingers, double timestamp,
                   int frame)
 {
   NSAutoreleasePool* pool = [[NSAutoreleasePool alloc] init];
-  fingersQua = [[NSUserDefaults standardUserDefaults] integerForKey:@"fingers"];
+  fingersQua = [[NSUserDefaults standardUserDefaults] integerForKey:kFingersNum];
+  float maxDistanceDelta = [[NSUserDefaults standardUserDefaults] floatForKey:kMaxDistanceDelta];
+  float maxTimeDelta = [[NSUserDefaults standardUserDefaults] integerForKey:kMaxTimeDelta] / 1000.f;
   
   if (needToClick) {
     if (nFingers == fingersQua) {
@@ -288,9 +291,9 @@ int touchCallback(int device, Finger* data, int nFingers, double timestamp,
     if (nFingers == 0) {
       NSTimeInterval elapsedTime = touchStartTime ? -[touchStartTime timeIntervalSinceNow] : 0;
       touchStartTime = NULL;
-      if (middleclickX + middleclickY && elapsedTime <= 0.5f) {
+      if (middleclickX + middleclickY && elapsedTime <= maxTimeDelta) {
         float delta = ABS(middleclickX - middleclickX2) + ABS(middleclickY - middleclickY2);
-        if (delta < 0.4f) {
+        if (delta < maxDistanceDelta) {
           // Emulate a middle click
           
           // get the current pointer location
@@ -316,7 +319,7 @@ int touchCallback(int device, Finger* data, int nFingers, double timestamp,
     } else {
       if (maybeMiddleClick == YES) {
         NSTimeInterval elapsedTime = -[touchStartTime timeIntervalSinceNow];
-        if (elapsedTime > 0.5f)
+        if (elapsedTime > maxTimeDelta)
           maybeMiddleClick = NO;
       }
     }

--- a/MiddleClick/PreferenceKeys.h
+++ b/MiddleClick/PreferenceKeys.h
@@ -1,0 +1,12 @@
+// The number of fingers needed to simulate a middle click.
+#define kFingersNum @"fingers"
+#define kFingersNumDefault 3
+
+// The maximum distance the cursor can travel between touch and release for a tap to be considered valid.
+// The position is normalized and values go from 0 to 1.
+#define kMaxDistanceDelta @"maxDistanceDelta"
+#define kMaxDistanceDeltaDefault 0.4f
+
+// The maximum interval in milliseconds between touch and release for a tap to be considered valid.
+#define kMaxTimeDeltaMs @"maxTimeDelta"
+#define kMaxTimeDeltaMsDefault 500

--- a/MiddleClick/TrayMenu.m
+++ b/MiddleClick/TrayMenu.m
@@ -1,4 +1,5 @@
 #import "TrayMenu.h"
+#import "PreferencesKey.h"
 #import "Controller.h"
 #import <Cocoa/Cocoa.h>
 
@@ -74,7 +75,7 @@
   bool clickMode = [myController getClickMode];
   NSString* clickModeInfo = clickMode ? @"Click" : @"Click or Tap";
   
-  int fingersQua = (int)[[NSUserDefaults standardUserDefaults] integerForKey:@"fingers"];
+  int fingersQua = (int)[[NSUserDefaults standardUserDefaults] integerForKey:@kFingersNum];
   
   [infoItem setTitle:[clickModeInfo stringByAppendingFormat: @" with %d Fingers", fingersQua]];
   [tapToClickItem setState:clickMode ? NSControlStateValueOff : NSControlStateValueOn];

--- a/MiddleClick/main.m
+++ b/MiddleClick/main.m
@@ -1,10 +1,24 @@
 #import "Controller.h"
+#import "PreferenceKeys.h"
 #import "TrayMenu.h"
 
 int main(int argc, char* argv[])
 {
+  id keys[] = {
+    kFingersNum,
+    kMaxDistanceDelta,
+    kMaxTimeDelta,
+  };
+  id objects[] = {
+      [NSNumber numberWithInt:kFingersNumDefault],
+      [NSNumber numberWithFloat:kMaxDistanceDeltaDefault],
+      [NSNumber numberWithInt:kMaxTimeDelta],
+  };
+  NSUInteger count = sizeof(objects) / sizeof(id);
   NSDictionary *appDefaults = [NSDictionary
-                               dictionaryWithObject:[NSNumber numberWithInt:3] forKey:@"fingers"];
+                               dictionaryWithObjects:objects
+                               forKeys:keys
+                               count:count];
   
   [[NSUserDefaults standardUserDefaults] registerDefaults:appDefaults];
   


### PR DESCRIPTION
The current time limit (500ms) only applies to the calculation of the distance. This means that the fingers can rest on the trackpad for an arbitrary amount and still trigger a middle click. This fixes that by checking the duration even when the finger are released.

On top of that, the current thresholds can easily cause conflicts with other gestures.

A maximum distance of 0.4f means you can swipe on the trackpad and still trigger a middle click (the position is normalized and it is always in the range [0..1]). Lower values, such as 0.05f, work better for detecting just taps.

A maximum duration of 400ms is also quite a lot for a tap. Something between 150ms/200ms works better for detecting just taps.

Instead of changing the default values, which maybe work for some, this adds two new preferences that allow to change those thresholds.

For example, to set the maximum distance to 0.05f and the maximum duration to 200ms, run:

```
defaults write com.rouge41.middleClick maxDistanceDelta 0.05
defaults write com.rouge41.middleClick maxTimeDelta 200
```